### PR TITLE
Added ability to parse multiple communities in a single High Five

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # high-five-tracker
 Tracks mentions in Fraser Health's high fives
 
-### To build
+### Run tests
 
 ```
-terraform init
+pip3 install -U pytest
+cd tests
+pytest
+```
 
+### Build
+
+```
+cd terraform/[dev|prod]
+terraform init
 terraform apply
 ```
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,6 +14,7 @@ RUN mkdir ${LAMBDA_TASK_ROOT}/config
 # Copy function code
 COPY high-five.py ${LAMBDA_TASK_ROOT}
 COPY confighelper.py ${LAMBDA_TASK_ROOT}
+COPY highfiveparser.py ${LAMBDA_TASK_ROOT}
 
 RUN chmod +x ${LAMBDA_TASK_ROOT}/high-five.py
 

--- a/src/high-five.py
+++ b/src/high-five.py
@@ -70,9 +70,19 @@ ses = boto3.client('ses', region_name=AWS_REGION)
 def high_five_has_name_of_interest(high_five):
   for name in NAMES_OF_INTEREST_LOWERCASE:
     if name in high_five['message'].lower():
-      if (high_five['community'] is None) or (high_five['community'].lower() in COMMUNITIES_OF_INTEREST_LOWERCASE):
-        logger.info(f"Found {name} in {high_five['community']}")
-        return True
+      community_matches = False
+
+      if len(high_five['communities']) == 0:
+        logger.info(f"No community specified in High Five, so found name {name} by default")
+        community_matches = True
+
+      for community_name in high_five['communities']:
+        if community_name.lower() in COMMUNITIES_OF_INTEREST_LOWERCASE:
+          logger.info(f"Found {name} in {community_name}")
+          community_matches = True
+          break
+
+      return community_matches
 
   return False
 

--- a/src/highfiveparser.py
+++ b/src/highfiveparser.py
@@ -1,0 +1,60 @@
+from bs4 import BeautifulSoup
+import re
+from datetime import datetime
+
+def sanitize_string(s):
+  if s is None:
+    return None
+
+  s = s.strip()
+  s = re.sub(r'[^\x20-\x7E]', '', s)
+  return s
+
+def parse_date(s):
+  if s is None:
+    return None
+
+  return datetime.strptime(s, '%b %d, %Y') # Example date is 'Apr 27, 2023'
+
+class HighFiveParser:
+  
+  @staticmethod
+  def parse_high_five(i):
+    soup = BeautifulSoup(i['Html'], 'html.parser')  
+
+    card_div = soup.find('div', {'class': 'highfive-card'})
+
+    community_div = card_div.find('span', {'class': 'field-communityname'}) if card_div is not None else None
+    community_text = community_div.text if community_div is not None else None
+
+    message_div = card_div.find('div', {'class': 'field-message'}) if card_div is not None else None
+    message_text = message_div.text if message_div is not None else None
+
+    date_div = card_div.find('div', {'class': 'field-highfivedate'}) if card_div is not None else None
+    date_text = date_div.text if date_div is not None else None
+
+    firstname_div = card_div.find('div', {'class': 'field-firstname'}) if card_div is not None else None
+    firstname_text = firstname_div.text if firstname_div is not None else None
+
+    return {
+      'id': i['Id'],
+      'date': parse_date(sanitize_string(date_text)),
+      'name': sanitize_string(firstname_text),
+      'community': sanitize_string(community_text),
+      'message': sanitize_string(message_text)
+    }
+
+  @staticmethod
+  def stringify_high_five_components(high_five):
+    components = [
+      f"Date: {high_five['date'].strftime('%b %-d, %Y')}" if high_five['date'] is not None else None,
+      f"From: {high_five['name']}" if high_five['name'] is not None else None,
+      f"Community: {high_five['community']}" if high_five['community'] is not None else None,
+      f"Message: {high_five['message']}"
+    ]
+
+    return filter(None, components)
+
+  @staticmethod
+  def stringify_high_five(high_five):
+    return "\n".join(HighFiveParser.stringify_high_five_components(high_five))

--- a/src/highfiveparser.py
+++ b/src/highfiveparser.py
@@ -47,7 +47,7 @@ class HighFiveParser:
   @staticmethod
   def stringify_high_five_components(high_five):
     components = [
-      f"Date: {high_five['date'].strftime('%b %-d, %Y')}" if high_five['date'] is not None else None,
+      f"Date: {HighFiveParser.stringify_date(high_five['date'])}" if high_five['date'] is not None else None,
       f"From: {high_five['name']}" if high_five['name'] is not None else None,
       f"Community: {high_five['community']}" if high_five['community'] is not None else None,
       f"Message: {high_five['message']}"
@@ -58,3 +58,7 @@ class HighFiveParser:
   @staticmethod
   def stringify_high_five(high_five):
     return "\n".join(HighFiveParser.stringify_high_five_components(high_five))
+
+  @staticmethod
+  def stringify_date(date):
+    return date.strftime('%b %-d, %Y')

--- a/src/highfiveparser.py
+++ b/src/highfiveparser.py
@@ -24,8 +24,8 @@ class HighFiveParser:
 
     card_div = soup.find('div', {'class': 'highfive-card'})
 
-    community_div = card_div.find('span', {'class': 'field-communityname'}) if card_div is not None else None
-    community_text = community_div.text if community_div is not None else None
+    community_divs = card_div.find_all('span', {'class': 'field-communityname'}) if card_div is not None else None
+    community_texts = list(map(lambda community_div : community_div.text, community_divs)) if community_divs is not None else []
 
     message_div = card_div.find('div', {'class': 'field-message'}) if card_div is not None else None
     message_text = message_div.text if message_div is not None else None
@@ -40,7 +40,7 @@ class HighFiveParser:
       'id': i['Id'],
       'date': parse_date(sanitize_string(date_text)),
       'name': sanitize_string(firstname_text),
-      'community': sanitize_string(community_text),
+      'communities': list(map(sanitize_string, community_texts)),
       'message': sanitize_string(message_text)
     }
 
@@ -48,12 +48,18 @@ class HighFiveParser:
   def stringify_high_five_components(high_five):
     components = [
       f"Date: {HighFiveParser.stringify_date(high_five['date'])}" if high_five['date'] is not None else None,
-      f"From: {high_five['name']}" if high_five['name'] is not None else None,
-      f"Community: {high_five['community']}" if high_five['community'] is not None else None,
-      f"Message: {high_five['message']}"
+      f"From: {high_five['name']}" if high_five['name'] is not None else None
     ]
 
-    return filter(None, components)
+    if len(high_five['communities']) == 1:
+      components.append(f"Community: {high_five['communities'][0]}")
+
+    if len(high_five['communities']) > 1:
+      components.append(f"Communities: {' and '.join(high_five['communities'])}")
+
+    components.append(f"Message: {high_five['message']}")
+
+    return list(filter(None, components))
 
   @staticmethod
   def stringify_high_five(high_five):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,3 @@
 requests
 boto3==1.26.131
-spacy==3.5.2
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz#egg=en_core_web_sm
 beautifulsoup4==4.12.2

--- a/tests/test_highfiveparser.py
+++ b/tests/test_highfiveparser.py
@@ -3,6 +3,33 @@ sys.path.append("../src")
 
 from highfiveparser import HighFiveParser
 
+# If a High Five contains no communities, then the resultant object should have an empty list
+def test_no_communities():
+  high_five_obj = {
+    "Id": "556f6b73-fb80-4562-854c-90c1bd4eaac0",
+    "Language": "en",
+    "Path": "/sitecore/content/FraserHealth/FraserHealth/Home/highfive/2023/high-five-8",
+    "Url": "https://www.fraserhealth.ca/highfive/2023/high-five-8",
+    "Name": None,
+    "Html": "<div class=\"highfive-card\"><div class=\"card-message-wrapper\"><div class=\"field-message\">The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better.</div><div class=\"field-highfivedate\">Sep 15, 2023</div><div class=\"field-firstname\">Samantha Johnstone </div></div></div>"
+  }
+
+  high_five = HighFiveParser.parse_high_five(high_five_obj)
+
+  assert high_five['id'] == "556f6b73-fb80-4562-854c-90c1bd4eaac0"
+  assert HighFiveParser.stringify_date(high_five['date']) == "Sep 15, 2023"
+  assert high_five['name'] == "Samantha Johnstone"
+  assert len(high_five['communities']) == 0
+  assert high_five['message'] == "The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better."
+
+  high_five_strings = HighFiveParser.stringify_high_five_components(high_five)
+
+  assert len(high_five_strings) == 3
+  assert high_five_strings[0] == "Date: Sep 15, 2023"
+  assert high_five_strings[1] == "From: Samantha Johnstone"
+  assert high_five_strings[2] == "Message: The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better."
+
+# If a High Five contains one or more communities, then the resultant object should have a list containing those communities
 def test_single_community():
   high_five_obj = {
     "Id": "556f6b73-fb80-4562-854c-90c1bd4eaac0",
@@ -18,6 +45,43 @@ def test_single_community():
   assert high_five['id'] == "556f6b73-fb80-4562-854c-90c1bd4eaac0"
   assert HighFiveParser.stringify_date(high_five['date']) == "Sep 15, 2023"
   assert high_five['name'] == "Samantha Johnstone"
-  assert high_five['community'] == "Maple Ridge"
+  assert len(high_five['communities']) == 1
+  assert high_five['communities'][0] == "Maple Ridge"
   assert high_five['message'] == "The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better."
-    
+
+  high_five_strings = HighFiveParser.stringify_high_five_components(high_five)
+
+  assert len(high_five_strings) == 4
+  assert high_five_strings[0] == "Date: Sep 15, 2023"
+  assert high_five_strings[1] == "From: Samantha Johnstone"
+  assert high_five_strings[2] == "Community: Maple Ridge"
+  assert high_five_strings[3] == "Message: The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better."
+
+# If a High Five contains one or more communities, then the resultant object should have a list containing those communities
+def test_two_communities():
+  high_five_obj = {
+    "Id": "a00d07de-93b9-435a-a3f7-9139565aae0e",
+    "Language": "en",
+    "Path": "/sitecore/content/FraserHealth/FraserHealth/Home/highfive/2023/high-five-7",
+    "Url": "https://www.fraserhealth.ca/highfive/2023/high-five-7",
+    "Name": None,
+    "Html": "<div class=\"highfive-card\"><div class=\"card-message-wrapper\"><div class=\"highfive-community\"><span class=\"community-label\">For</span><span class=\"field-communityname\">Maple Ridge</span><span class=\"field-communityname\">Fraser Health region</span></div><div class=\"field-message\">I received the highest quality of care during my stay in Ridge Meadows [Hospital]. Every nurse was cheerful, caring and invested in providing the best possible care. They regularly checked in on me and answered any questions I had. I feel fortunate to have been in the care of exceptionally dedicated, compassionate and kind nursing staff. Please convey my appreciation and thanks.</div><div class=\"field-highfivedate\">Aug 21, 2023</div><div class=\"field-firstname\">Carol</div></div></div>"
+  }
+
+  high_five = HighFiveParser.parse_high_five(high_five_obj)
+
+  assert high_five['id'] == "a00d07de-93b9-435a-a3f7-9139565aae0e"
+  assert HighFiveParser.stringify_date(high_five['date']) == "Aug 21, 2023"
+  assert high_five['name'] == "Carol"
+  assert len(high_five['communities']) == 2
+  assert high_five['communities'][0] == "Maple Ridge"
+  assert high_five['communities'][1] == "Fraser Health region"
+  assert high_five['message'] == "I received the highest quality of care during my stay in Ridge Meadows [Hospital]. Every nurse was cheerful, caring and invested in providing the best possible care. They regularly checked in on me and answered any questions I had. I feel fortunate to have been in the care of exceptionally dedicated, compassionate and kind nursing staff. Please convey my appreciation and thanks."
+
+  high_five_strings = HighFiveParser.stringify_high_five_components(high_five)
+
+  assert len(high_five_strings) == 4
+  assert high_five_strings[0] == "Date: Aug 21, 2023"
+  assert high_five_strings[1] == "From: Carol"
+  assert high_five_strings[2] == "Communities: Maple Ridge and Fraser Health region"
+  assert high_five_strings[3] == "Message: I received the highest quality of care during my stay in Ridge Meadows [Hospital]. Every nurse was cheerful, caring and invested in providing the best possible care. They regularly checked in on me and answered any questions I had. I feel fortunate to have been in the care of exceptionally dedicated, compassionate and kind nursing staff. Please convey my appreciation and thanks."

--- a/tests/test_highfiveparser.py
+++ b/tests/test_highfiveparser.py
@@ -1,0 +1,23 @@
+import sys
+sys.path.append("../src")
+
+from highfiveparser import HighFiveParser
+
+def test_single_community():
+  high_five_obj = {
+    "Id": "556f6b73-fb80-4562-854c-90c1bd4eaac0",
+    "Language": "en",
+    "Path": "/sitecore/content/FraserHealth/FraserHealth/Home/highfive/2023/high-five-8",
+    "Url": "https://www.fraserhealth.ca/highfive/2023/high-five-8",
+    "Name": None,
+    "Html": "<div class=\"highfive-card\"><div class=\"card-message-wrapper\"><div class=\"highfive-community\"><span class=\"community-label\">For</span><span class=\"field-communityname\">Maple Ridge</span></div><div class=\"field-message\">The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better.</div><div class=\"field-highfivedate\">Sep 15, 2023</div><div class=\"field-firstname\">Samantha Johnstone </div></div></div>"
+  }
+
+  high_five = HighFiveParser.parse_high_five(high_five_obj)
+
+  assert high_five['id'] == "556f6b73-fb80-4562-854c-90c1bd4eaac0"
+  assert HighFiveParser.stringify_date(high_five['date']) == "Sep 15, 2023"
+  assert high_five['name'] == "Samantha Johnstone"
+  assert high_five['community'] == "Maple Ridge"
+  assert high_five['message'] == "The nurses, physician and other staff made my young daughter and I feel taken care of. While chatting with us, the friendly greeter gave my child a goodie bag with toys and activities. The sweet discharge nurse gave her a Popsicle, and the attending doctor was caring and kind. Absolutely over and above any hospital visit I've ever had. Thank you to the staff for being kind and making an ill little girl feel better."
+    


### PR DESCRIPTION
- Some High Fives have > 1 community specified, so now the `'communities'` field after parsing always contains an array of all communities found, or else an empty array
- Split out the code for parsing/stringifying High Fives so that it can be tested independently
- Added unit tests for parsing/stringifying High Fives
- Removed the NLP stuff (which was unused anyway) which tried to automatically detect people mentioned in the High Five

Fixes https://github.com/euan-forrester/high-five-tracker/issues/6