### PR TITLE
Also need to register to and cc emails, not just from

### DIFF
--- a/terraform/modules/lambda/email.tf
+++ b/terraform/modules/lambda/email.tf
@@ -1,3 +1,11 @@
 resource "aws_ses_email_identity" "from_email" {
   email = var.from_email
 }
+
+resource "aws_ses_email_identity" "to_email" {
+  email = var.to_email
+}
+
+resource "aws_ses_email_identity" "cc_email" {
+  email = var.cc_email
+}


### PR DESCRIPTION
Testing in dev, I only used one address for all 3 emails. I assumed that only `from` emails would need to be registered with SES. But it turns out you need to register `to` and `cc` emails as well.