### PR TITLE
Alarm fixes

### DIFF
--- a/terraform/modules/alarms/high-five-system.tf
+++ b/terraform/modules/alarms/high-five-system.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "most-recent-high-five-age-days" {
   namespace                 = var.metrics_namespace
   period                    = "300"
   statistic                 = "Maximum"
-  threshold                 = "30" # High Fives are uploaded to the system by hand, so even when they're fresh they're dated a week or two prior to the current date
+  threshold                 = "60" # High Fives are uploaded to the system by hand, so even when they're fresh they're dated a week or two prior to the current date
   treat_missing_data        = "ignore"
   alarm_description         = "Alerts if the High Five system is not generating new High Fives"
   alarm_actions             = [aws_sns_topic.alarms.arn]

--- a/terraform/modules/alarms/high-five-system.tf
+++ b/terraform/modules/alarms/high-five-system.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "most-recent-high-five-age-days" {
   period                    = "300"
   statistic                 = "Maximum"
   threshold                 = "30" # High Fives are uploaded to the system by hand, so even when they're fresh they're dated a week or two prior to the current date
-  treat_missing_data        = "notBreaching"
+  treat_missing_data        = "ignore"
   alarm_description         = "Alerts if the High Five system is not generating new High Fives"
   alarm_actions             = [aws_sns_topic.alarms.arn]
   insufficient_data_actions = [aws_sns_topic.alarms.arn]

--- a/terraform/modules/alarms/lambda.tf
+++ b/terraform/modules/alarms/lambda.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "eventbridge_failedinvocations" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  treat_missing_data        = "notBreaching"
+  treat_missing_data        = "ignore"
   alarm_description         = "Alerts if EventBridge fails to publish a cron event to lambda"
   alarm_actions             = [aws_sns_topic.alarms.arn]
   insufficient_data_actions = [aws_sns_topic.alarms.arn]

--- a/terraform/modules/lambda/lambda.tf
+++ b/terraform/modules/lambda/lambda.tf
@@ -26,9 +26,12 @@ data "aws_caller_identity" "lambda" {
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "${var.application_name}-${var.environment}-iam_for_lambda"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
 
-  inline_policy {
-    name = "email-logs-lambda-policy-${var.environment}"
+resource "aws_iam_role_policy" "iam_for_lambda_policy" {
+  name = "email-logs-lambda-policy-${var.environment}"
+  role = aws_iam_role.iam_for_lambda.id
+
     policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -72,7 +75,6 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 POLICY
-  }
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_events" {


### PR DESCRIPTION
- Fix alarm for inactive high five system from reverting to OK on sparse data
- Fixed deprecated terraform found while doing the above
- Increase threshold for the inactive system alarm from `30` to `60` days with no new High Fives: this alarm is meant to alert if the High Five system itself stops being updated, but we've tripped it a couple times now and they've continued to post new High Fives afterward