### PR TITLE
Maintain a list of High Fives we have previously sent an email about

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Note that you need to create & populate `~/.aws/credentials`. There is an exampl
 Log into your docker repository:
 
 ```
-eval "$(aws ecr get-login --no-include-email --region us-west-2)"
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin <aws account id>.dkr.ecr.us-west-2.amazonaws.com
 ```
 
 Then build and push your image:
 
 ```
 cd src
-docker build -f ./Dockerfile .
+docker build -t high-five-tracker-[dev|prod] . --provenance=false
 docker images
 docker tag <ID of image you just built> <URI of high-five-tracker-[dev|prod] repository in ECR: use AWS console to find>
 docker push <URI of high-five-tracker-[dev|prod] repository in ECR>

--- a/src/common/confighelper.py
+++ b/src/common/confighelper.py
@@ -53,7 +53,13 @@ class ConfigHelperFile(ConfigHelper):
     def get_environment(self):
         return self.environment
 
+    def setArray(self, key, value, is_secret=False):
+        self.set(key, json.dumps(value), is_secret)
+
     def set(self, key, value, is_secret=False):
+        if len(value) > 4096:
+            raise configparser.ValueError(message=f'Length of value exceeds AWS limit of 4kB. Value: "{value}"')
+
         try:
             # This doesn't update the actual .ini file -- it must just update the in-memory store of our config.
             # It might be better to just do nothing here? Not sure
@@ -136,9 +142,15 @@ class ConfigHelperParameterStore(ConfigHelper):
 
         return value
 
+    def setArray(self, key, value, is_secret=False):
+        self.set(key, json.dumps(value), is_secret)
+
     def set(self, key, value, is_secret=False):
 
         full_path = self._get_full_path(key)
+
+        if len(value) > 4096:
+            raise configparser.ValueError(message=f'Length of value exceeds AWS limit of 4kB. Value: "{value}"')
 
         self._set_in_parameter_store(full_path, value, is_secret)
 

--- a/src/config/config.ini
+++ b/src/config/config.ini
@@ -9,8 +9,8 @@ retry-backoff-factor=0.5
 
 run-at-script-startup=true
 
-previous-most-recent-high-five-id=dummy
-set-most-recent-high-five-id=true
+previously-sent-high-five-ids=["149fbada-6d2d-427e-b68a-01f7d1ce6bef", "5880562b-034f-4850-8558-92b4637c0151", "f7e7bff8-e3be-41ae-9695-0788ff18072d", "38dace2f-5120-41aa-89a6-7695e57ecad8", "9557576c-5809-4f6a-a842-6e28443bce2e", "b5484951-cab2-43ac-8639-c983fc258d91"]
+set-previously-sent-high-five-ids=true
 
 metrics-namespace=high-five-tracker-dev
 send-metrics=true

--- a/src/highfiveparser.py
+++ b/src/highfiveparser.py
@@ -48,6 +48,7 @@ class HighFiveParser:
   @staticmethod
   def stringify_high_five_components(high_five):
     components = [
+      f"ID: {high_five['id']}" if high_five['id'] is not None else None,
       f"Date: {HighFiveParser.stringify_date(high_five['date'])}" if high_five['date'] is not None else None,
       f"From: {high_five['name']}" if high_five['name'] is not None else None
     ]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -10,7 +10,7 @@ module "lambda" {
   cron_expression         = "cron(0 16 * * ? *)"  # Run every day at 4:00 PM UTC = 9:00 AM PDT or 8:00 AM PST
   #cron_expression         = "cron(*/5 * * * ? *)"  # Run every 5 minutes for testing
   
-  set_most_recent_high_five_id = true
+  set_previously_sent_high_five_ids = true
 
   metrics_namespace       = var.application_name
   send_metrics            = true

--- a/terraform/modules/lambda/parameter-store.tf
+++ b/terraform/modules/lambda/parameter-store.tf
@@ -113,20 +113,20 @@ resource "aws_ssm_parameter" "from_email" {
   value       = var.from_email
 }
 
-resource "aws_ssm_parameter" "set_most_recent_high_five_id" {
-  name        = "/${var.application_name}/${var.environment}/set-most-recent-high-five-id"
-  description = "Whether to set the most recent High Five ID encountered during this invocation of the lambda function"
+resource "aws_ssm_parameter" "set_previously_sent_high_five_ids" {
+  name        = "/${var.application_name}/${var.environment}/set-previously-sent-high-five-ids"
+  description = "Whether to set the list of IDs for which we have previously sent an email"
   type        = "String"
-  value       = var.set_most_recent_high_five_id
+  value       = var.set_previously_sent_high_five_ids
 }
 
-# We're going to use this as external storage, to persist the most recent ID encountered between invocations of our lamdba function
+# We're going to use this as external storage, to persist the IDs of the high fives that we've previously sent emails about
 # So, ignore changes to the value of this parameter
-resource "aws_ssm_parameter" "previous_most_recent_high_five_id" {
-  name        = "/${var.application_name}/${var.environment}/previous-most-recent-high-five-id"
-  description = "The ID of the most recent High Five ID encountered on the previous run of the lambda expression"
+resource "aws_ssm_parameter" "previously_sent_high_five_ids" {
+  name        = "/${var.application_name}/${var.environment}/previously-sent-high-five-ids"
+  description = "JSON-formatted array of the IDs of the High Fives for which we have previously sent an email"
   type        = "String"
-  value       = "dummy"
+  value       = "[\"dummy\"]"
 
   lifecycle {
     ignore_changes = [

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -7,7 +7,7 @@ variable "region" {
 variable "application_name" {
 }
 
-variable "set_most_recent_high_five_id" {
+variable "set_previously_sent_high_five_ids" {
 }
 
 variable "send_metrics" {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -9,7 +9,7 @@ module "lambda" {
 
   cron_expression         = "cron(0 16 * * ? *)"  # Run every day at 4:00 PM UTC = 9:00 AM PDT or 8:00 AM PST
 
-  set_most_recent_high_five_id = true
+  set_previously_sent_high_five_ids = true
 
   metrics_namespace       = var.application_name
   send_metrics            = true


### PR DESCRIPTION
It turns out that High Fives are not inserted in chronological order, and we can get new High Fives added to the system from dates earlier than the previous last High Five that we saw

So, by only keeping track of the previous last High Five that we saw, we were missing some new High Fives that were added to the system.

This changes the system to keep track of all High Fives for which we've previously sent an email, and then to send emails for any new interesting High Fives encountered that are not on that list

This has the side benefit that if we change our search criteria at a point in the future (adding a new name, or new location, for example) now all High Fives will be compared against those new search terms and we may unearth an old High Five that now matches

Also, updated our documentation on how to build and run the project

Fixes https://github.com/euan-forrester/high-five-tracker/issues/23

Deployed to prod